### PR TITLE
Fix derivation breakage due to nixpkgs switch to 3.12

### DIFF
--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  pythonForIDA = pkgs.python3.withPackages (ps: with ps; [ rpyc ]);
+  pythonForIDA = pkgs.python313.withPackages (ps: with ps; [ rpyc ]);
 in
 pkgs.stdenv.mkDerivation rec {
   pname = "ida-pro";
@@ -105,7 +105,7 @@ pkgs.stdenv.mkDerivation rec {
     done
 
     # Manually patch libraries that dlopen stuff.
-    patchelf --add-needed libpython3.12.so $out/lib/libida.so
+    patchelf --add-needed libpython3.13.so $out/lib/libida.so
     patchelf --add-needed libcrypto.so $out/lib/libida.so
 
     # Some libraries come with the installer.


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/033d93e793a5dfa4abd900e36cfabc038827af0f

nixpkgs switched to Python 3.13 as the default `python3` version, which breaks the build due to manually specifying `python3.12.so` in the ELF patching script.

I also explicitly specified `python313Packages` instead of `python3Packages` to hopefully avoid this problem in the future.

I've tested this and it works fine for me, but I can imagine this breaking plugins occasionally, so it might make sense to add an optional argument to the derivation for specifying a python version or something (or just roll back to 3.12 explicitly).