### PR TITLE
ida-pro: add missing libsecret dependency

### DIFF
--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -108,6 +108,7 @@ pkgs.stdenv.mkDerivation rec {
     # Manually patch libraries that dlopen stuff.
     patchelf --add-needed libpython3.13.so $out/lib/libida.so
     patchelf --add-needed libcrypto.so $out/lib/libida.so
+    patchelf --add-needed libsecret-1.so.0 $out/lib/libida.so
 
     # Some libraries come with the installer.
     addAutoPatchelfSearchPath $IDADIR


### PR DESCRIPTION
IDA Pro raises a warning "cannot find libsecret-1.so.0" during runtime. Idk how it affects functionality but why not to include to prevent unexpected errors in future

```
QApplication: invalid style override 'adwaita-dark' passed, ignoring it.
        Available styles: Windows, Fusion
qt.qpa.wayland.textinput: virtual void QT::QtWaylandClient::QWaylandTextInputv3::zwp_text_input_v3_leave(wl_surface*) Got leave event for surface 0x0 focused surface 0x55c24751c780
qt.qpa.wayland.textinput: virtual void QT::QtWaylandClient::QWaylandTextInputv3::zwp_text_input_v3_leave(wl_surface*) Got leave event for surface 0x0 focused surface 0x55c246e67c40
qt.qpa.wayland.textinput: virtual void QT::QtWaylandClient::QWaylandTextInputv3::zwp_text_input_v3_leave(wl_surface*) Got leave event for surface 0x0 focused surface 0x55c247dd0be0
qt.qpa.wayland.textinput: virtual void QT::QtWaylandClient::QWaylandTextInputv3::zwp_text_input_v3_leave(wl_surface*) Got leave event for surface 0x0 focused surface 0x55c2472393d0
Cannot initialize secret storage: Could not load "libsecret-1.so.0": libsecret-1.so.0: cannot open shared object file: No such file or directory: No such file or directory
```

This PR fixes this warning