### PR TITLE
Pass dependency via `requireFile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # Nix Flake for IDA Pro
 
-You can use the overlay provided by this flake along with your own IDA installer runfile to build your IDA Pro with Nix and use it on NixOS.
+You can use the overlay provided by this flake along with your own IDA installer runfile to build an IDA Pro package with Nix and use it on NixOS.
 
 ## How to Use
 
-First, whether flakes are used or not, the IDA Pro installer must be made available for Nix.
+First, the IDA Pro installer must be made available for Nix.
 
-This can be done by checking it into a private Git repository, supplying the build the path to the package, fetching the installer via the network, etc.
-
-For example, the installer can be added to the store like so:
+Add the installer to the store like so:
 
 ```sh
-nix store add-file ida-pro_90_x64linux.run
+nix store add-file ida-pro_92_x64linux.run
 ```
 
-This will then give you the store path, which is later used to instantiate the package.
+It will then be picked up automatically as a dependency.
 
 ### With Flakes
 
@@ -35,14 +33,11 @@ nixpkgs.overlays = [
 ];
 ```
 
-Then, you can instantiate the package, supplying it with your locally available installer
+Then, you can instantiate the package.
 
 ```nix
 environment.systemPackages = [
-    (callPackage ida-pro {
-        # Alternatively, fetch the installer through `fetchurl`, use a local path, etc.
-        runfile = /nix/store/z83flk6c9fm9li3gs13vbamq2szg9rwf-ida-pro_90_x64linux.run;
-    })
+    ida-pro
 ];
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743814133,
-        "narHash": "sha256-drDyYyUmjeYGiHmwB9eOPTQRjmrq3Yz26knwmMPLZFk=",
+        "lastModified": 1765803225,
+        "narHash": "sha256-xwaZV/UgJ04+ixbZZfoDE8IsOWjtvQZICh9aamzPnrg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "250b695f41e0e2f5afbf15c6b12480de1fe0001b",
+        "rev": "ac9a217389ee622d4e1e727c4efcc9c4bc9089ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,8 @@
     }:
     {
       overlays.default = self: super: {
-        ida-pro = import ./packages/ida-pro.nix;
+        # use super here to inherit allowUnfree status
+        ida-pro = super.callPackage ./packages/ida-pro.nix {};
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,20 @@
 
   outputs =
     {
+      nixpkgs,
       ...
     }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in
     {
       overlays.default = self: super: {
         # use super here to inherit allowUnfree status
         ida-pro = super.callPackage ./packages/ida-pro.nix {};
       };
+      packages.${system}.default = pkgs.callPackage ./packages/ida-pro.nix {};
     };
 }

--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  extraFiles ? "",
   ...
 }:
 let
@@ -127,6 +128,10 @@ pkgs.stdenv.mkDerivation rec {
         --prefix LD_LIBRARY_PATH : $out/lib
       ln -s $IDADIR/$bb $out/bin/$bb
     done
+
+    if [ -n "${extraFiles}" ]
+      then cp -r "${extraFiles}"/* $out/opt/
+    fi
 
     runHook postInstall
   '';

--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   lib,
-  runfile,
   ...
 }:
 let
@@ -11,7 +10,11 @@ pkgs.stdenv.mkDerivation rec {
   pname = "ida-pro";
   version = "9.2.0.250908";
 
-  src = runfile;
+  src = pkgs.requireFile {
+    name = "ida-pro_92_x64linux.run";
+    url = "https://my.hex-rays.com/";
+    sha256 = "aadd0f8ae972b84f94f2a974834abf1619f3bd933b3b4d8275f9c50008d05ae1";
+  };
 
   desktopItem = pkgs.makeDesktopItem {
     name = "ida-pro";

--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -9,7 +9,7 @@ let
 in
 pkgs.stdenv.mkDerivation rec {
   pname = "ida-pro";
-  version = "9.2.0.250908";
+  version = "9.2.250908";
 
   src = pkgs.requireFile {
     name = "ida-pro_92_x64linux.run";


### PR DESCRIPTION
This PR passes the installer file via [requireFile](https://github.com/NixOS/nixpkgs/blob/master/doc/build-helpers/fetchers.chapter.md#requirefile-requirefile), which makes the package much cleaner to use.

I also added support for `nix run`; if no explicit argument is required, this works 'out of the box' (provided, of course, that you have the installer in /nix/store)

I took the liberty of changing the version number from `9.2.0.250908` to `9.2.250908`. There isn't any `.0`, it's simply IDA Pro 9.2 (or, according to the title bar, 9.2.250908)