### PR TITLE
Add binary patch support

### DIFF
--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -3,6 +3,11 @@
   lib,
   extraFiles ? "",
   hexPatches ? [],
+  # hexPatches: hex patterns to substitute in specified files immediately after
+  # install. Can be used, for example, to replace the embedded SSL certificates
+  # for compatibility with a self-hosted Lumina server.
+  # Since IDA Pro is distributed as a binary, such patching is the only recourse
+  # available to us for interoperability purposes.
   ...
 }:
 let

--- a/packages/ida-pro.nix
+++ b/packages/ida-pro.nix
@@ -2,10 +2,20 @@
   pkgs,
   lib,
   extraFiles ? "",
+  hexPatches ? [],
   ...
 }:
 let
   pythonForIDA = pkgs.python313.withPackages (ps: with ps; [ rpyc ]);
+  patchScript = lib.concatMapStringsSep "\n" (p:
+    let
+      forcecntDecl =
+        lib.optionalString (p ? assertCount)
+          "my $forcecnt = ${toString p.assertCount};";
+          in ''
+      perl -0777 -pi -e '${forcecntDecl} my $cnt = (s/\Q''${\pack("H*","${p.from}")}\E/''${\pack("H*","${p.to}")}/g) || 0; die "Expected $forcecnt substitutions, did $cnt\n" if defined $forcecnt && $cnt != $forcecnt' "$IDADIR/${p.filename}"
+    ''
+  ) hexPatches;
 in
 pkgs.stdenv.mkDerivation rec {
   pname = "ida-pro";
@@ -34,6 +44,7 @@ pkgs.stdenv.mkDerivation rec {
     copyDesktopItems
     autoPatchelfHook
     qt6.wrapQtAppsHook
+    perl
   ];
 
   # We just get a runfile in $src, so no need to unpack it.
@@ -103,6 +114,8 @@ pkgs.stdenv.mkDerivation rec {
     # to copy it to fix permissions and patch the executable.
     $(cat $NIX_CC/nix-support/dynamic-linker) $src \
       --mode unattended --debuglevel 4 --prefix $IDADIR
+
+    ${patchScript}
 
     # Link the exported libraries to the output.
     for lib in $IDADIR/*.so $IDADIR/*.so.6; do


### PR DESCRIPTION
Connecting to a private third-party Lumina server like [lumen](https://github.com/naim94a/lumen) currently requires one of:
1. Disable SSL entirely
2. Run a local intercepting proxy (very clunky)
3. Patch the binary to instead use our own SSL certificate (replacing .crt files is no longer enough, as the certificate is embedded in the binary now)

In general, patching the IDA binary is (surprisingly) a workflow with some official support; prior to the migration to Apple Silicon, all platforms would [*mutate the binary*](https://github.com/eset/idapython-src/blob/master/idapyswitch_linux.cpp) to swap out what Python library was used, until this caused too much grief with code signing.

Since IDA is non-free software, and only distributed as a binary file, we are unable to apply e.g. source-level patches to fix it/apply workarounds. This PR thus adds support for the install-time application of user-specified hex patches.